### PR TITLE
Fixed exceptions in case no form fields are provided

### DIFF
--- a/Block/Designer.php
+++ b/Block/Designer.php
@@ -294,7 +294,11 @@ class Designer extends Template
                 'value' => $product->getData('printess_document')
             );
 
-            $formFields = json_decode($product->getData('printess_form_fields'), true);
+            $formFields = $product->getData('printess_form_fields');
+
+            if(isset($formFields)) {
+                $formFields = json_decode($formFields, true);
+            }
 
             if (is_array($formFields)) {
 


### PR DESCRIPTION
There is an issue in case no form fields are used and the configuration is left empty. json_decode does not support decoding of null values anymore