### PR TITLE
Fixed wrong data type.

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -101,7 +101,7 @@ class InstallData implements InstallDataInterface
             'printess_form_fields',
             [
                 'group' => 'Printess',
-                'type' => 'varchar',
+                'type' => 'text',
                 'backend' => '',
                 'frontend' => '',
                 'label' => 'Form Fields (JSON)',


### PR DESCRIPTION
var char fields are only 255 byte in size. We have to use text for more than 255 characters which is recommended for json data